### PR TITLE
Allow any command passed as `args`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       env:
         CI: 'true'
       with:
-        args: test
+        args: npm test
 ```
 
 > Note: You will need to let Puppeteer know not to download Chromium. By setting the env of your install task to PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = 'true' so it does not install conflicting versions of Chromium.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,14 +8,13 @@ export DISPLAY=:99.0
 export PUPPETEER_EXEC_PATH="google-chrome-stable"
 
 # Run commands
-for cmd in "$@"; do
-    echo "Running '$cmd'..."
-    if npm "$cmd"; then
-        # no op
-        echo "Successfully ran '$cmd'"
-    else
-        exit_code=$?
-        echo "Failure running '$cmd', exited with $exit_code"
-        exit $exit_code
-    fi
-done
+cmd=$@
+echo "Running '$cmd'!"
+if $cmd; then
+    # no op
+    echo "Successfully ran '$cmd'"
+else
+    exit_code=$?
+    echo "Failure running '$cmd', exited with $exit_code"
+    exit $exit_code
+fi


### PR DESCRIPTION
### BREAKING CHANGE

In the previous version, the usage of `args` was limited to `npm` [lifecycle scripts](https://docs.npmjs.com/misc/scripts) like `test`, `install`, `publish`... Using a custom npm script like `npm run whatever` was not possible since the bash script split the command on whitespace. Furthermore, this rescritiong was preventing other use cases like issuing a custom command or script.

With this release, `args` can be any command like
- `npm test`
- `npm run whatever`
- `./run.sh`
- `some-binary`
