### PR TITLE
Add the ability to run in sandbox mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN  apt-get update \
 RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
    && mkdir -p /home/pptruser/Downloads \
    && chown -R pptruser:pptruser /home/pptruser
+   && chown -R pptruser:pptruser /github/workspace
+   && chmod 755 /github/workspace
 
 # Run everything after as non-privileged user.
 USER pptruser

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,14 @@ RUN  apt-get update \
      && apt-get install -y google-chrome-stable --no-install-recommends \
      && rm -rf /var/lib/apt/lists/*
 
+# Add user so we don't need --no-sandbox.
+RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+   && mkdir -p /home/pptruser/Downloads \
+   && chown -R pptruser:pptruser /home/pptruser
+
+# Run everything after as non-privileged user.
+USER pptruser
+
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 


### PR DESCRIPTION
## Description

Before this, there was an assumption that all usage of this action would be ran un the `--no-sandbox` flag. This is not recommended by the Puppeteer team.  This implements creating a user and allowing that user access to all the resources needed to run the test. 

closes #17 