### PR TITLE
Remove breaking change message

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,10 +16,5 @@ if $cmd; then
 else
     exit_code=$?
     echo "Failure running '$cmd', exited with $exit_code"
-    echo ''
-    echo 'BREAKING CHANGE !!!'
-    echo 'We introduced a breaking change with the args field.'
-    echo 'You might just need to change `args: test` to `args: npm test`.'
-    echo 'For more details check out https://github.com/mujo-code/puppeteer-headful/pull/9'
     exit $exit_code
 fi


### PR DESCRIPTION
While I was hunting for an issue with our E2E tests, I came across this breaking change message. For a short moment I was confused, but then I remembered that I added this message my self one year ago 😆 

Maybe time to remove it!? What do you think?