### PR TITLE
add no-sandbox parameter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Then you will need to change the way you launch Puppeteer. We export out a nifty
 
 ```javascript
 browser = await puppeteer.launch({
+  args: ['--no-sandbox'],
   executablePath: process.env.PUPPETEER_EXEC_PATH, // set by docker container
   headless: false,
   ...


### PR DESCRIPTION
Adds missing information on required `--no-sandbox` parameter.

Related to #17