### PR TITLE
add action.yml file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,10 @@
+name: 'Puppeteer Headful'
+description: 'Runs headless puppeteer'
+inputs:
+  args:
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.args }}


### PR DESCRIPTION
I'm currently trying to use https://github.com/Wandalen/wretry.action with a puppeteer step in my github actions workflow that's a bit unreliable, but it doesn't work because there's no [action.yml](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#creating-an-action-metadata-file
) in this (super useful!) workflow package.

```yml
  - name: run puppeteer e2e tests
    uses: Wandalen/wretry.action@v1.0.11
    with:
      action: mujo-code/puppeteer-headful@v2
      with: |
        args: yarn e2e
      attempt_limit: 3
      attempt_delay: 30000
```
![Screenshot 2022-05-27 at 06 41 26](https://user-images.githubusercontent.com/101902546/170684530-41123842-48a0-49f9-9722-ce6c3565e46c.png)

I'm not 100% if the syntax is correct here as I don't know if `args` needs to be a named input but I think it should be ok?