### PR TITLE
Update entrypoint.sh to cope with newest puppeteers

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
 
 # Export some variables
 export DISPLAY=:99.0
-export PUPPETEER_EXEC_PATH="google-chrome-stable"
+export PUPPETEER_EXEC_PATH=`which google-chrome-stable`
 
 # Run commands
 cmd=$@


### PR DESCRIPTION
Puppeteer expects the full exec path or one of these: https://pptr.dev/api/puppeteer.chromereleasechannel