### PR TITLE
Fix PUPPETEER_EXEC_PATH for puppeteer 22.* and above

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.9.0
+FROM node:lts
 
 LABEL "com.github.actions.name"="Puppeteer Headful"
 LABEL "com.github.actions.description"="A GitHub Action / Docker image for Puppeteer, the Headful Chrome Node API"
@@ -10,8 +10,6 @@ LABEL "homepage"="https://github.com/mujo-code/puppeteer-headful"
 LABEL "maintainer"="Jacob Lowe"
 
 RUN  apt-get update \
-     # See https://crbug.com/795759
-     && apt-get install -yq libgconf-2-4 \
      # Install latest chrome dev package, which installs the necessary libs to
      # make the bundled version of Chromium that Puppeteer installs work.
      && apt-get install -y wget xvfb --no-install-recommends \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
 
 # Export some variables
 export DISPLAY=:99.0
-export PUPPETEER_EXEC_PATH="google-chrome-stable"
+export PUPPETEER_EXEC_PATH="$(which google-chrome-stable)"
 
 # Run commands
 cmd=$@


### PR DESCRIPTION
Makes PUPPETEER_EXEC_PATH absolute and updates base image. Fixes #133 