### PR TITLE
Add libgcc dependency in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,12 @@ RUN  apt-get update \
      && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
      && apt-get update \
      && apt-get install -y google-chrome-stable --no-install-recommends \
-     && rm -rf /var/lib/apt/lists/*
+     && rm -rf /var/lib/apt/lists/* \
+     && wget https://mirrors.edge.kernel.org/ubuntu/pool/main/g/gcc-10/gcc-10-base_10-20200411-0ubuntu1_amd64.deb \
+     && wget https://mirrors.edge.kernel.org/ubuntu/pool/main/g/gcc-10/libgcc-s1_10-20200411-0ubuntu1_amd64.deb \
+     && dpkg -i gcc-10-base_10-20200411-0ubuntu1_amd64.deb \
+     && dpkg -i libgcc-s1_10-20200411-0ubuntu1_amd64.deb
+
 
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true


### PR DESCRIPTION
# Description
I've encounter the following error in docker build
```
9.673 Some packages could not be installed. This may mean that you have
9.673 requested an impossible situation or if you are using the unstable
9.673 distribution that some required packages have not yet been created
9.673 or been moved out of Incoming.
9.673 The following information may help to resolve the situation:
9.673 
9.673 The following packages have unmet dependencies:
9.711  google-chrome-stable : Depends: libgcc-s1 (>= 4.2) but it is not installable
9.719 E: Unable to correct problems, you have held broken packages.
```

# Solution
According to [google-chrome-stable : Depends: libgcc-s1 (>= 4.2) but it is not installable](https://askubuntu.com/questions/1524103/google-chrome-stable-depends-libgcc-s1-4-2-but-it-is-not-installable), I've added the libgcc dependency in apt install